### PR TITLE
travis: add minimum toolchain and clippy passes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,26 @@
 language: rust
 rust:
+  - 1.26.0  # minimum supported toolchain
+  - 1.29.2  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
-  fast_finish: true
+
+env:
+  global:
+    - CLIPPY_RUST_VERSION=1.29.2
+
+before_script:
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      rustup component add clippy-preview;
+    fi'
+
+script:
+  - cargo test
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      cargo clippy;
+    fi'


### PR DESCRIPTION
This adds two additional travis passes:
 * a minimum toolchain check
 * a clippy run (with warnings disabled for now, pending cleanup)