### PR TITLE
cargo: openssh-keys release 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"
 documentation = "https://docs.rs/openssh-keys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.4.1"
+version = "0.4.2-alpha.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"
 documentation = "https://docs.rs/openssh-keys"


### PR DESCRIPTION
This is a minor release, to align on latest `base64` dependency.