### PR TITLE
travis: update minimum and clippy toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
-  - 1.26.0  # minimum supported toolchain
-  - 1.29.2  # pinned toolchain for clippy
+  - 1.28.0  # minimum supported toolchain
+  - 1.31.0  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -12,11 +12,11 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.29.2
+    - CLIPPY_RUST_VERSION=1.31.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      rustup component add clippy-preview;
+      rustup component add clippy;
     fi'
 
 script:


### PR DESCRIPTION
This bumps the minimum toolchain requirement to 1.28.0, due to newer
`block-buffer` release.