### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.5.0-alpha.0"
+version = "0.5.0"
 edition = "2018"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.5.0"
+version = "0.5.1-alpha.0"
 edition = "2018"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"


### PR DESCRIPTION
Changes:
- API change: Switch error-handling library from `error-chain` to `thiserror`
- Update to Rust 2018
- Fix build warnings with newer Rust
- Update `base64` to 0.13
- Exclude tooling configuration from packaged crate