### PR TITLE
release-checklist: clarify crates.io access

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -14,7 +14,7 @@ This guide requires:
  * `cargo-release` (suggested: `cargo install -f cargo-release`)
  * A verified account on crates.io
  * Write access to this GitHub project
- * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members)
+ * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members), which will give you upload access to crates.io
 
 ## Release checklist
 


### PR DESCRIPTION
Mention that the "Fedora CoreOS Crates Owners" GitHub group is what will
give push access to crates.io.