### PR TITLE
cargo: openssh-keys release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.5.1-alpha.0"
+version = "0.6.0"
 edition = "2018"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"


### PR DESCRIPTION
Changes:
 * cargo: allow md-5 and sha2 0.10
 * cargo: explicitly set `sign-tag` 
 * dependabot: switch to weekly cadence
 * git: rename `master` branch to `main`
 * github/ISSUE_TEMPLATE: add release checklist
 * lib: Support Hardware Security Keys
 * templates: release process updates
 * workflows: bump MSRV and lint toolchain