### PR TITLE
cargo: bump MSRV to 1.58.0 and edition to 2021

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.51.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.64.0
 
@@ -51,10 +49,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Detect crate MSRV
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "MSRV=$msrv" >> $GITHUB_ENV
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env.MSRV }}
       - name: cargo build (release)
         run: cargo build --release
       - name: cargo test (release)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openssh-keys"
 version = "0.6.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.58.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "openssh-keys"
 version = "0.6.0"
 edition = "2018"
+rust-version = "1.58.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"
 documentation = "https://docs.rs/openssh-keys"


### PR DESCRIPTION
Match our other projects.  The base64 bump will require at least 1.57.0.