### PR TITLE
cargo: drop the version range for md-5, sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ exclude = [".github", ".gitignore", "examples", "fixtures"]
 # Private dependencies.
 base64 = "0.21"
 byteorder = "1.1"
-md-5 = ">= 0.9, < 0.11"
-sha2 = ">= 0.9, < 0.11"
+# Do not use a range on the crates md-5 or sha2. RustCrypto crate
+# versions cannot be mixed and matched. Doing so will cause hard
+# to understand build failures. Read about it at
+# https://github.com/coreos/openssh-keys/issues/89
+md-5 = "0.10"
+sha2 = "0.10"
 thiserror = "1.0"
 # Public dependencies, exposed through library API.
 # <none>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Changes:
 
+- Require `md-5` 0.10, `sha2` 0.10 to avoid mismatched Rust Crypto dependencies
 
 
 ## openssh-keys 0.6.1 (2023-06-01)


### PR DESCRIPTION
cargo.toml: drop the version range for md-5, sha2 

https://github.com/coreos/openssh-keys/issues/89