### PR TITLE
Implement Packit to openssh-keys

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,39 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+actions:
+    changelog-entry:
+        - bash -c 'echo "- New upstream release"'
+    post-upstream-clone:
+        - wget https://src.fedoraproject.org/rpms/rust-openssh-keys/raw/rawhide/f/rust-openssh-keys.spec
+
+specfile_path: rust-openssh-keys.spec
+
+upstream_tag_template: v{version}
+
+# add or remove files that should be synced
+files_to_sync:
+    - .packit.yaml
+    - rust-openssh-keys.spec 
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: openssh-keys   
+# downstream (Fedora) RPM package name
+downstream_package_name: rust-openssh-keys
+
+jobs: 
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-all
+
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - fedora-all
+
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-all

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,10 @@
 
 Changes:
 
- - Require Rust ≥ 1.75.0
+- Require Rust ≥ 1.75.0
+- Add Packit support for Fedora packaging
+
+
 
 ## openssh-keys 0.6.2 (2023-06-27)
 


### PR DESCRIPTION
This PR is about using Packit to automate releases for [openssh-keys](https://github.com/coreos/openssh-keys). We tested it in coreos-installer and found it effective. Now, we're working in an epic to add it in all coreos packages repos. 

You can learn more about Packit in its documentation [here](https://packit.dev/docs).