### PR TITLE
Cargo.toml: bump MSRV to 1.75.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.71.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.77.2
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openssh-keys"
 version = "0.6.2"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.75.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"
 documentation = "https://docs.rs/openssh-keys"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-
+ - Require Rust ≥ 1.75.0
 
 ## openssh-keys 0.6.2 (2023-06-27)
 


### PR DESCRIPTION
To incorporate [Packit into OpenSSH-keys](https://github.com/coreos/openssh-keys/pull/98), we must increase the MSRV to 1.75.0. This alteration necessitates an update to our lint as well, as we can't have our lint version be less than our MSRV