### PR TITLE
docs/release-notes: update for release 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,9 @@
 # Release notes
 
-## Upcoming openssh-keys 0.6.3 (unreleased)
+## Upcoming openssh-keys 0.6.4 (unreleased)
+
+
+## openssh-keys 0.6.3 (2024-04-30)
 
 Changes:
 


### PR DESCRIPTION
These changes are part of the OpenSSH Keys 0.6.3 [release checklist](https://github.com/coreos/openssh-keys/issues/100). 
We are making this release with the goal of adding Packit to this project.



