### PR TITLE
cargo: openssh-keys release 0.6.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-keys"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]


### PR DESCRIPTION
These changes are part of the OpenSSH Keys 0.6.4 [checklist release](https://github.com/coreos/openssh-keys/issues/104).
We are making this release with the goal of adding Packit to this project.