### PR TITLE
Improve Packit adding fedora-all to propose downstream job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,7 @@ jobs:
 - job: propose_downstream
   trigger: release
   dist_git_branches:
-    - fedora-rawhide
+    - fedora-all
 
 - job: koji_build
   trigger: commit


### PR DESCRIPTION
We are changing from ` fedora-rawhide` to ` fedora-all` in` propose-downstream` job. This will release the changes to all the branches, not only rawhide, making the releases faster and simpler. 

